### PR TITLE
Style resume; change apostrophes to HTML symbol

### DIFF
--- a/src/About.js
+++ b/src/About.js
@@ -9,9 +9,9 @@ export const About = () => {
       <h2 className='hello'>Hello</h2>
       <div className='about-me'>
         <img className='leta' src='/images/headshot.jpg' alt='headshot' />
-        <p>I'm omnivorously curious and take unabashed, dorky joy in learning new things. In my previous professional life, I worked at the Denver Museum of Nature & Science, where I encouraged critical thinking and creativity through informal science education.</p>
-        <p>I graduate from the Turing School of Software & Design's Front-End Engineering program in August 2017.</p>
-        <p>I have a passion for creating websites and applications that are intuitive, accessible, and which make people's lives better.</p>
+        <p>I&#8217;m omnivorously curious and take unabashed, dorky joy in learning new things. In my previous professional life, I worked at the Denver Museum of Nature & Science, where I encouraged critical thinking and creativity through informal science education.</p>
+        <p>I graduate from the Turing School of Software & Design&#8217;s Front-End Engineering program in August 2017.</p>
+        <p>I have a passion for creating websites and applications that are intuitive, accessible, and which make people&#8217;s lives better.</p>
         <Link className='contact-me-link' to='/Contact'>contact me</Link>
       </div>
     </article>

--- a/src/Resume.js
+++ b/src/Resume.js
@@ -1,9 +1,57 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
+import { Portfolio } from './Portfolio';
+import { Contact } from './Contact';
+import './assets/stylesheets/Resume.css';
 
 export const Resume = () => {
   return (
     <article className='resume'>
-      <div>Resume goes here</div>
+      <h2 className='resume-header'>Projects</h2>
+      <div className='resume-display'>
+        <Link className='resume-link' to='/Projects'>Click to See Projects</Link>
+      </div>
+      <h2 className='resume-header'>Skills</h2>
+      <div className='resume-display'>
+        <p>HTML5 + CSS 3</p>
+        <p>JavaScript (ES6)</p>
+        <p>React/Redux</p>
+        <p>jQuery</p>
+        <p>UX/UI Design</p>
+        <p>Testing (Mocha, Chai, Enzyme, Jest)</p>
+        <p>WAI-ARIA</p>
+        <p>Sketch</p>
+        <p>Node</p>
+        <p>Express</p>
+      </div>
+      <h2 className='resume-header'>Experience</h2>
+      <div className='resume-display'>
+        <div className='experience-group'>
+          <h3 className='experience'>Lab Programs Assistant</h3>
+          <h3 className='company'>Denver Museum of Nature &amp; Science</h3>
+          <p>I fostered critical thinking and curiosity in students and families through informal science education in a biology lab. I created protocols and streamlined processes in the lab, as well as training and managing a corps of 150+ volunteers.</p>
+        </div>
+        <div className='experience-group'>
+          <h3 className='experience'>SEO Copywriter</h3>
+          <h3 className='company'>GreenTent Web Design &amp; Marketing</h3>
+          <p>I wrote persuasive, information-rich copy to capture user interactions and boost keyword rankings. I also wrote user personas, conducted client interviews, and worked closely with the design team on information architecture and UXD.</p>
+        </div>
+      </div>
+      <h2 className='resume-header'>Education</h2>
+      <div className='resume-display'>
+        <div className='experience-group'>
+          <h3 className='experience'>Turing School of Software &amp; Design</h3>
+          <p>Front-End Engineering Program</p>
+        </div>
+        <div className='experience-group'>
+          <h3 className='experience'>Coe College</h3>
+          <p>Bachelor of Arts in Creative Writing</p>
+        </div>
+      </div>
+      <h2 className='resume-header'>Contact Me</h2>
+      <div className='resume-display'>
+        <Link className='resume-link' to='/Contact'>Say hello</Link>
+      </div>
     </article>
   )
 }

--- a/src/assets/stylesheets/Aside.css
+++ b/src/assets/stylesheets/Aside.css
@@ -5,6 +5,7 @@
   display: flex;
   flex-direction: column;
   justify-content: center;
+  position: fixed;
 }
 
 .hero {

--- a/src/assets/stylesheets/Resume.css
+++ b/src/assets/stylesheets/Resume.css
@@ -1,0 +1,59 @@
+.resume {
+  text-align: center;
+  padding-bottom: 50px;
+}
+
+.resume-display {
+  background-color: rgba(255, 255, 255, 0.8);
+  width: 30vw;
+  padding: 3vh 5vw;
+  margin-bottom: 10vh;
+}
+
+.resume-header {
+  font-size: 2.5em;
+  text-shadow: 2px 2px 17px rgba(23, 165, 167, 0.4);
+  text-transform: uppercase;
+  letter-spacing: 8px;
+  color: #ffffff;
+}
+
+.resume-link {
+  font-family: 'Lato', sans-serif;
+  text-decoration: none;
+  text-transform: uppercase;
+  letter-spacing: 2px;
+  color: #FFAFB0;
+}
+
+.resume-link:hover {
+  letter-spacing: 5px;
+}
+
+.resume-display p {
+  font-weight: 300;
+  line-height: 200%;
+  letter-spacing: 2px;
+}
+
+.experience-group {
+  margin: 5vh 1vw;
+}
+
+.experience {
+  font-size: 1em;
+  font-weight: 400;
+  text-transform: uppercase;
+  letter-spacing: 5px;
+  color: #000000;
+  margin: 0;
+}
+
+.company {
+  font-size: 1em;
+  font-weight: 400;
+  text-transform: uppercase;
+  letter-spacing: 2px;
+  color: #FFAFB0;
+  margin: 0;
+}

--- a/src/success.js
+++ b/src/success.js
@@ -5,7 +5,7 @@ export const success = () => {
   return (
     <article className='success'>
       <h2 className='form-greeting'>Thanks for your note!</h2>
-      <h2 className='form-greeting'>I'll get back to you soon.</h2>
+      <h2 className='form-greeting'>I&#8217;ll get back to you soon.</h2>
     </article>
   )
 }


### PR DESCRIPTION
In this PR:
- Styled the Resume component
- Included links to Projects page and Contact page
- Changed apostrophes to HTML symbols instead
- Added ```position: fixed``` to the CSS for the Aside component

Resume demo:
[Link to Resume demo](http://g.recordit.co/kfpIhrb2E0.gif)